### PR TITLE
Deal properly with AND between verses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub fn clean_ref(test_ref: &str) -> String {
         .to_uppercase()
         .replace(" ", "")
         .replace(".", ":") // for chapter:verse; book punctuation gets stripped later
-        .replace("AND", "&")
+        .replace("AND", ",")
 }
 
 // Convert book chapter:verses into integer code string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@ pub fn clean_ref(test_ref: &str) -> String {
         .replace(" ", "")
         .replace(".", ":") // for chapter:verse; book punctuation gets stripped later
         .replace("AND", ",")
+        .replace("&", ",")
 }
 
 // Convert book chapter:verses into integer code string

--- a/src/tests/test.rs
+++ b/src/tests/test.rs
@@ -7,6 +7,9 @@ fn test_parse() {
 		parse("Job, Lev - Num"),
 		Some(vec!["18001001-18999999".to_string(), "3001001-4999999".to_string()]));
 	assert_eq!(
+		parse("Revelation 12:9 and 20:2"),
+		Some(vec!["66012009".to_string(), "66020002".to_string()]));
+	assert_eq!(
 		parse("Rev. 22.1, Rev 21"),
 		Some(vec!["66022001".to_string(), "66021001-66021999".to_string()]));
 	assert_eq!(

--- a/src/tests/test.rs
+++ b/src/tests/test.rs
@@ -10,6 +10,9 @@ fn test_parse() {
 		parse("Revelation 12:9 and 20:2"),
 		Some(vec!["66012009".to_string(), "66020002".to_string()]));
 	assert_eq!(
+		parse("Revelation 12:9 & 20:2"),
+		Some(vec!["66012009".to_string(), "66020002".to_string()]));
+	assert_eq!(
 		parse("Rev. 22.1, Rev 21"),
 		Some(vec!["66022001".to_string(), "66021001-66021999".to_string()]));
 	assert_eq!(


### PR DESCRIPTION
I noticed that "Revelation 12:9 and 20:2" did not parse correctly in the Genesis 3:1-5 commentary. This should now be fixed.